### PR TITLE
Improve pattern & option handling by ESLint

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Check types
         run: yarn run check-types
       - name: Lint
-        run: yarn run lint
+        run: yarn run lint --no-cache --quiet
       - name: Build
         run: yarn run build
       - name: Test

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "compile-ts": "babel ./src --out-dir ./lib --extensions .ts --ignore '**/*.test.ts'",
     "copy-configs-to-lib": "babel-node --extensions .ts build/copy-configs-to-lib.ts",
     "generate-typings": "tsc --project tsconfig.generate-typings.json",
-    "lint": "eslint --quiet *.js **/*.ts",
+    "lint": "eslint --cache '**/*.{js,ts}'",
     "prepublishOnly": "yarn run lint && yarn run check-types && yarn run test && yarn run build && yarn run generate-typings",
     "test": "jest --config jest.standalone.config.js"
   },

--- a/src/utils/initializeProject.ts
+++ b/src/utils/initializeProject.ts
@@ -34,6 +34,7 @@ const scripts: { key: string; value: string }[] = [
   { key: 'check-types', value: 'tsc' },
   { key: 'compile-ts', value: 'babel ./src --out-dir ./lib --extensions .ts --ignore \'**/*.test.ts\''},
   { key: 'generate-typings', value: 'tsc --project tsconfig.generate-typings.json' },
+  { key: 'lint', value: "eslint --cache '**/*.{js,ts}'" },
   { key: 'prepublishOnly', value: 'yarn run check-types && yarn test && yarn run build' },
   { key: 'test', value: 'jest' },
 ];


### PR DESCRIPTION
- Simplified the recursive pattern and enclosed it in quotes: ESLint understands the pattern correctly, but not all versions of Bash (including the version bundled with macOS) do; the quoted string bypasses shell expansion
- Moved the `--quiet` flag from the main linting script to the CI script
- Added the `--cache` flag to default linting, the `--no-cache` flag to linting in the CI workflow